### PR TITLE
feat(build): publish an android/armv7 (32-bit) release archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,15 +78,32 @@ jobs:
           - { goos: windows, goarch: amd64, ext: ".exe" }
           - { goos: windows, goarch: arm64, ext: ".exe" }
           - { goos: android, goarch: arm64, ldextra: "-checklinkname=0" }
+          # android/arm is the one target the Go toolchain refuses to build
+          # without external linking, so it needs an NDK clang and cgo.
+          - { goos: android, goarch: arm, goarm: "7", ldextra: "-checklinkname=0", cgo: "1", ndk: true }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
+      - name: Set up Android NDK
+        if: matrix.ndk
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+          local-cache: true
+      - name: Export the android/arm cross-compiler
+        if: matrix.ndk
+        run: |
+          bin="${{ steps.ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          test -x "$bin/armv7a-linux-androideabi21-clang"
+          echo "CC=$bin/armv7a-linux-androideabi21-clang" >> "$GITHUB_ENV"
+          echo "CXX=$bin/armv7a-linux-androideabi21-clang++" >> "$GITHUB_ENV"
       - name: Build
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: ${{ matrix.cgo || '0' }}
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,21 @@ jobs:
           cache: true
       - name: Install UPX
         run: sudo apt-get update && sudo apt-get install -y upx-ucl
+      - name: Set up Android NDK
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+          local-cache: true
+      - name: Export the android/arm cross-compiler
+        # android/arm is the one target the Go toolchain refuses to build
+        # without external linking, so it needs a real NDK clang. See the
+        # stremio-server-android-arm build in .goreleaser.yml.
+        run: |
+          bin="${{ steps.ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          test -x "$bin/armv7a-linux-androideabi21-clang"
+          echo "ANDROID_ARM_CC=$bin/armv7a-linux-androideabi21-clang" >> "$GITHUB_ENV"
+          echo "ANDROID_ARM_CXX=$bin/armv7a-linux-androideabi21-clang++" >> "$GITHUB_ENV"
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,12 @@ version: 2
 
 project_name: stremio-server
 
+# Defaults so a local `goreleaser build` works when the NDK toolchain bin dir
+# is on PATH; the release workflow overrides these with absolute paths.
+env:
+  - ANDROID_ARM_CC={{ if index .Env "ANDROID_ARM_CC" }}{{ .Env.ANDROID_ARM_CC }}{{ else }}armv7a-linux-androideabi21-clang{{ end }}
+  - ANDROID_ARM_CXX={{ if index .Env "ANDROID_ARM_CXX" }}{{ .Env.ANDROID_ARM_CXX }}{{ else }}armv7a-linux-androideabi21-clang++{{ end }}
+
 before:
   hooks:
     - go mod tidy
@@ -54,9 +60,44 @@ builds:
     goarch:
       - arm64
 
+  # Android (32-bit armv7) — the ABI shipped by most Android TV / Google TV
+  # devices (Chromecast with Google TV included): an ARMv8 kernel with a
+  # 32-bit userspace, where only armeabi-v7a binaries load.
+  #
+  # Unlike every other target this one CANNOT be built CGO-free: the Go
+  # toolchain hard-requires external linking for android/arm
+  # ("android/arm requires external (cgo) linking"), so it needs an NDK
+  # cross-compiler. CC/CXX come from ANDROID_ARM_CC/ANDROID_ARM_CXX (set by
+  # the release workflow via setup-ndk, defaulting to the plain NDK tool
+  # names so a local build works with the NDK toolchain bin dir on PATH).
+  #
+  # Enabling cgo also pulls in the C++ github.com/anacrolix/go-libutp
+  # implementation instead of the pure-Go uTP fallback the other targets
+  # use, hence CXX is required too.
+  - id: stremio-server-android-arm
+    main: ./cmd/stremio-server
+    binary: stremio-server
+    env:
+      - CGO_ENABLED=1
+      - CC={{ .Env.ANDROID_ARM_CC }}
+      - CXX={{ .Env.ANDROID_ARM_CXX }}
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -checklinkname=0
+      - -X main.buildVersion={{ .Version }}
+      - -X main.buildCommit={{ .ShortCommit }}
+      - -X main.buildDate={{ .Date }}
+    goos:
+      - android
+    goarch:
+      - arm
+    goarm:
+      - "7"
+
 upx:
   # Linux only: macOS Gatekeeper rejects upx-packed Mach-O, and upx on
-  # android/arm64 can break the loader.
+  # android can break the loader.
   - enabled: true
     compress: best
     lzma: true
@@ -68,6 +109,7 @@ archives:
     ids:
       - stremio-server
       - stremio-server-android
+      - stremio-server-android-arm
     formats: tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
## Why

Most Android TV / Google TV devices — Chromecast with Google TV included — pair an ARMv8 kernel with a **32-bit userspace**, so only `armeabi-v7a` binaries load. Until now the sole Android asset was `arm64`, leaving those devices with nothing to run.

Surfaced via rivulet-kodi/plugin.video.rivulet#1, where the Kodi addon's server-binary download failed on a Chromecast with Google TV.

## Why it isn't a one-line config change

`android/arm` is the one target that **cannot** be built CGO-free — the Go toolchain hard-requires external linking for it, unlike `android/arm64`:

```
$ CGO_ENABLED=0 GOOS=android GOARCH=arm GOARM=7 go build ./cmd/stremio-server
android/arm requires external (cgo) linking, but cgo is not enabled
```

So it gets its own build id with an NDK cross-compiler. `CXX` is needed as well as `CC`, because enabling cgo pulls in the C++ `github.com/anacrolix/go-libutp` implementation instead of the pure-Go uTP fallback every other target uses.

## Changes

- `.goreleaser.yml`: new `stremio-server-android-arm` build (`CGO_ENABLED=1`, `goarch: arm`, `goarm: "7"`), registered in `archives.ids`. `CC`/`CXX` come from `ANDROID_ARM_CC`/`ANDROID_ARM_CXX`, defaulting to the plain NDK tool names so a local `goreleaser build` works with the toolchain bin dir on `PATH`.
- `.github/workflows/release.yml`: provisions the NDK with `nttld/setup-ndk` (r27c, cached) and exports absolute clang paths, with an executability guard so a layout change fails loudly rather than silently falling back to host `gcc`.
- The `upx` block stays Linux-only, so the new archive is not packed.

## Verification

`goreleaser check` passes, and a full `goreleaser release --snapshot --clean --skip=publish` produces the complete nine-asset matrix, unchanged apart from the addition:

```
stremio-server_Android_arm64.tar.gz
stremio-server_Android_armv7.tar.gz     <-- new
stremio-server_Darwin_arm64.tar.gz
stremio-server_Darwin_x86_64.tar.gz
stremio-server_Linux_arm64.tar.gz
stremio-server_Linux_armv7.tar.gz
stremio-server_Linux_x86_64.tar.gz
stremio-server_Windows_arm64.zip
stremio-server_Windows_x86_64.zip
checksums.txt
```

The new artifact is a genuine 32-bit Android binary and is listed in `checksums.txt`:

```
ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked,
interpreter /system/bin/linker, for Android 21, built by NDK r29, stripped

8e7e8c9a913b3b0cb38fa8f00faa39492d9a95bf6603eaa5c6707f4ffb8b4402  stremio-server_Android_armv7.tar.gz
```

## Downstream effect

Android 10+ forbids executing a binary from an app's own writable data directory (W^X), so Kodi cannot spawn this itself on those devices. But Termux is a separate app with an exec-capable home directory, so the `armv7` archive can now be unpacked and run there and reached at `127.0.0.1:11470` — **no root required**. That path was previously impossible on 32-bit devices for want of a matching asset.
