### PR TITLE
build: include android/armv7 in make build-all and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,13 +64,17 @@ make fmt          # gofmt -s -w .
 make fmt-check    # fail if not gofmt -s clean
 make lint         # golangci-lint run ./... (if installed)
 make swagger      # regenerate docs/swagger.{yaml,json} from // @… annotations (needs swaggo/swag)
-make build-all    # cross-compile all 8 release targets → dist/
+make build-all    # cross-compile all 9 release targets → dist/ (android/armv7 needs ANDROID_ARM_CC)
 make smoke        # ./scripts/smoke.sh end-to-end API test (needs a running build)
 ```
 
-Cross-compile targets (all `CGO_ENABLED=0`): `linux/{amd64,arm64,armv7}`,
-`darwin/{amd64,arm64}`, `windows/{amd64,arm64}`, `android/arm64` (needs
-`-ldflags=-checklinkname=0`). Benchmarks: `go test -bench . -benchmem ./internal/api/`.
+Cross-compile targets: `linux/{amd64,arm64,armv7}`, `darwin/{amd64,arm64}`,
+`windows/{amd64,arm64}`, `android/arm64` — all `CGO_ENABLED=0`, with
+`android/arm64` needing `-ldflags=-checklinkname=0`. `android/armv7` is the
+lone exception: the Go toolchain hard-requires external linking for it, so it
+needs `CGO_ENABLED=1` plus an NDK clang via `ANDROID_ARM_CC`/`ANDROID_ARM_CXX`
+(which also pulls in the C++ `go-libutp` instead of the pure-Go uTP fallback).
+Benchmarks: `go test -bench . -benchmem ./internal/api/`.
 
 ## Code Conventions & Common Patterns
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,15 @@ LDFLAGS     := -s -w -checklinkname=0 \
 GOFLAGS     := -trimpath -ldflags "$(LDFLAGS)"
 
 # CGO is not required; disabling it makes every target cross-compile as pure Go.
+# The single exception is android/arm -- see ANDROID_ARM_CC in build-all.
 export CGO_ENABLED := 0
+
+# android/arm is the one published target the Go toolchain refuses to build
+# without external linking, so it needs an NDK clang. Point ANDROID_ARM_CC at
+# one (or put the NDK toolchain bin dir on PATH) and build-all includes it;
+# otherwise that single target is skipped with a notice.
+ANDROID_ARM_CC  ?= armv7a-linux-androideabi21-clang
+ANDROID_ARM_CXX ?= armv7a-linux-androideabi21-clang++
 
 .PHONY: all build run test race vet fmt fmt-check lint tidy clean smoke build-all swagger help
 
@@ -52,7 +60,8 @@ smoke: build ## Run the end-to-end API smoke test
 clean: ## Remove build artifacts
 	rm -rf $(BINARY) $(DIST)
 
-# Cross-compile every published target (pure Go, CGO disabled).
+# Cross-compile every published target (pure Go, CGO disabled -- except
+# android/arm, which cannot be built that way).
 # android/arm64 needs -checklinkname=0 (already in LDFLAGS) for github.com/wlynxg/anet on Go 1.23+.
 build-all: ## Cross-build all release targets into dist/
 	@mkdir -p $(DIST)
@@ -64,6 +73,13 @@ build-all: ## Cross-build all release targets into dist/
 	GOOS=windows GOARCH=amd64        go build $(GOFLAGS) -o $(DIST)/$(BINARY)_windows_amd64.exe  $(MAIN)
 	GOOS=windows GOARCH=arm64        go build $(GOFLAGS) -o $(DIST)/$(BINARY)_windows_arm64.exe  $(MAIN)
 	GOOS=android GOARCH=arm64        go build $(GOFLAGS) -o $(DIST)/$(BINARY)_android_arm64      $(MAIN)
+	@if command -v $(ANDROID_ARM_CC) >/dev/null 2>&1; then \
+		CGO_ENABLED=1 CC=$(ANDROID_ARM_CC) CXX=$(ANDROID_ARM_CXX) \
+		GOOS=android GOARCH=arm GOARM=7 \
+		go build $(GOFLAGS) -o $(DIST)/$(BINARY)_android_armv7 $(MAIN); \
+	else \
+		echo "skipping android/armv7: $(ANDROID_ARM_CC) not found (set ANDROID_ARM_CC to an NDK clang)"; \
+	fi
 	@echo "built -> $(DIST)/"
 
 help: ## Show targets


### PR DESCRIPTION
Follow-up consistency fix to #5. The published target matrix grew to 9 with the `android/armv7` release archive, but `make build-all` and the `AGENTS.md` target list still described 8, so the local cross-build no longer matched what the release produces.

- `Makefile`: `build-all` now builds `android/armv7` too, guarded on an NDK clang being available. `ANDROID_ARM_CC`/`ANDROID_ARM_CXX` default to the plain NDK tool names (found on `PATH`), and when no compiler is present that single target degrades to a skip notice instead of failing the whole target — `build-all` stays usable on a machine without an NDK.
- `AGENTS.md`: corrected "8 release targets" to 9, and documented why `android/armv7` is the lone `CGO_ENABLED=1` target (Go hard-requires external linking for it, which also swaps the pure-Go uTP fallback for the C++ `go-libutp`).

No shipped code changes — the release itself is driven by `.goreleaser.yml`, which already covers this target.

## Verification

With an NDK, `dist/` holds all 9 binaries:

```
stremio-server_android_arm64      stremio-server_linux_arm64
stremio-server_android_armv7      stremio-server_linux_armv7
stremio-server_darwin_amd64       stremio-server_windows_amd64.exe
stremio-server_darwin_arm64       stremio-server_windows_arm64.exe
stremio-server_linux_amd64
```

Without one, the other 8 still build and the guard reports:

```
skipping android/armv7: armv7a-linux-androideabi21-clang not found (set ANDROID_ARM_CC to an NDK clang)
```
